### PR TITLE
fix: Option usedefaults re-assign

### DIFF
--- a/src/string-mask.js
+++ b/src/string-mask.js
@@ -78,10 +78,15 @@
 
     function StringMask(pattern, opt) {
         this.options = opt || {};
-        this.options = {
-            reverse: this.options.reverse || false,
-            usedefaults: this.options.usedefaults || this.options.reverse
-        };
+
+        if (typeof this.options.reverse === 'undefined') {
+            this.options.reverse = false;
+        }
+
+        if (typeof this.options.usedefaults === 'undefined') {
+            this.options.usedefaults = this.options.reverse;
+        }
+
         this.pattern = pattern;
     }
 


### PR DESCRIPTION
```js
var options = {
  reverse: true,
  usedefaults: false
}
var formatter = new StringMask('+00 (00) 0000-0000', options)
```
Old code;

```js
usedefaults: this.options.usedefaults || this.options.reverse
```

OR operator (||) returns the condition on the right side but the expected one was to have returned the left side.

OR for defaults can be convenient because it is short and easy to write but to booleans parameters it was not good.